### PR TITLE
06_runtime_view hotfix

### DIFF
--- a/docs/06_runtime_view.adoc
+++ b/docs/06_runtime_view.adoc
@@ -5,7 +5,7 @@
 
 When an unidentified user logs in.
 
-[plantuml,"Sequence diagram",png]
+[plantuml,"Sequence diagram 1",png]
 ----
 actor User
 participant LoMap
@@ -20,7 +20,7 @@ User <- LoMap: The page for identified users is shown
 
 When an identified user sees a personalized map
 
-[plantuml,"Sequence diagram",png]
+[plantuml,"Sequence diagram 2",png]
 ----
 actor User
 participant LoMap


### PR DESCRIPTION
La segunda imagen se guardaba con el mismo nombre que la primera